### PR TITLE
Append flymake-phpcs to php-mode-hook instead of adding it at the front

### DIFF
--- a/flymake-phpcs.el
+++ b/flymake-phpcs.el
@@ -74,7 +74,7 @@
                  '("\\(.*\\):\\([0-9]+\\):\\([0-9]+\\): \\(.*\\)" 1 2 3 4))
     (let ((mode-and-masks (flymake-get-file-name-mode-and-masks "example.php")))
       (setcar mode-and-masks 'flymake-phpcs-init))
-    (add-hook 'php-mode-hook (lambda() (flymake-mode 1)))))
+    (add-hook 'php-mode-hook (lambda() (flymake-mode 1)) t)))
 
 (provide 'flymake-phpcs)
 ;;; flymake-phpcs.el ends here


### PR DESCRIPTION
By appending flymake-phpcs to php-mode-hook instead of just adding it
to the front we give other functions added to the hook a chance to run
before flymake-phpcs.

This gives them a chance to set i.e. flymake-phpcs-standard to the
desired standard before phpcs is run.
