### PR TITLE
Made `flymake-phpcs-standard' safe-local-variable

### DIFF
--- a/README.mkdn
+++ b/README.mkdn
@@ -28,7 +28,7 @@ something like the following to your .emacs:
 (setq flymake-phpcs-command "~/projects/emacs-flymake-phpcs/bin/flymake_phpcs")
 
 ;; Customize the coding standard checked by phpcs
-(setq flymake-phpcs-standard
+(set-default 'flymake-phpcs-standard
   "~/projects/devtools/php_codesniffer/MyCompanyStandard")
 
 ;; Show the name of sniffs in warnings (eg show

--- a/flymake-phpcs.el
+++ b/flymake-phpcs.el
@@ -1,6 +1,6 @@
 ;;; flymake-phpcs.el --- Flymake handler for PHP to invoke PHP-CodeSniffer
 ;;
-;; Copyright (C) 2011-2012  Free Software Foundation, Inc.
+;; Copyright (C) 2011-2012, 2014  Free Software Foundation, Inc.
 ;;
 ;; Author: Sam Graham <libflymake-phpcs-emacs BLAHBLAH illusori.co.uk>
 ;; Maintainer: Sam Graham <libflymake-phpcs-emacs BLAHBLAH illusori.co.uk>
@@ -42,6 +42,9 @@
 (defcustom flymake-phpcs-standard "PEAR"
   "The coding standard to pass to phpcs via --standard."
   :group 'flymake-phpcs
+  :safe (lambda (value)
+          (and (string-or-null-p value)
+               (not (file-exists-p value))))
   :type 'string)
 
 (defcustom flymake-phpcs-show-rule nil


### PR DESCRIPTION
This makes it possible to set a specifik standard in a local variables
block at the end of a file or in a dir-locals.el.
