### PR TITLE
Fixed when real file is in a sym linked directory.

### DIFF
--- a/flymake-phpcs.el
+++ b/flymake-phpcs.el
@@ -1,6 +1,6 @@
 ;;; flymake-phpcs.el --- Flymake handler for PHP to invoke PHP-CodeSniffer
 ;;
-;; Copyright (C) 2011-2012  Free Software Foundation, Inc.
+;; Copyright (C) 2011-2012, 2014  Free Software Foundation, Inc.
 ;;
 ;; Author: Sam Graham <libflymake-phpcs-emacs BLAHBLAH illusori.co.uk>
 ;; Maintainer: Sam Graham <libflymake-phpcs-emacs BLAHBLAH illusori.co.uk>
@@ -55,7 +55,7 @@
                         'flymake-create-temp-copy
                         'flymake-create-temp-inplace)))
          (local-file (file-relative-name temp-file
-                       (file-name-directory buffer-file-name))))
+                       (file-name-directory (file-truename buffer-file-name)))))
     (list flymake-phpcs-command
       (append
         (list local-file)


### PR DESCRIPTION
If one of the directories in the path is a symbolic link the errors from
phpcs will not be picked up. This change makes it work (and still works
when there are no symbolic links).

Based on an issue on arnested/drupal-mode#14.
